### PR TITLE
Database template

### DIFF
--- a/database/ex-dock.sql
+++ b/database/ex-dock.sql
@@ -2239,8 +2239,8 @@ ALTER TABLE ONLY public.multi_select_attributes_int
 ALTER TABLE ONLY public.multi_select_attributes_float
   ADD CONSTRAINT "FK_9" FOREIGN KEY (attribute_key) REFERENCES public.custom_product_attributes(attribute_key);
 
-ALTER TABLE ONLY public.templates
-  ADD CONSTRAINT "FK_72" FOREIGN KEY (template_key) REFERENCES public.blocks(template_key);
+ALTER TABLE ONLY public.blocks
+  ADD CONSTRAINT "FK_72" FOREIGN KEY (template_key) REFERENCES public.templates(template_key);
 
 --
 

--- a/src/main/kotlin/com/ex_dock/ex_dock/ClassLoaderDummy.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/ClassLoaderDummy.kt
@@ -1,0 +1,5 @@
+package com.ex_dock.ex_dock
+
+class ClassLoaderDummy {
+  //Please don't add anything to this. This is just a test double for class loader
+}

--- a/src/main/kotlin/com/ex_dock/ex_dock/MainVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/MainVerticle.kt
@@ -52,7 +52,6 @@ class MainVerticle : AbstractVerticle() {
       .listen(props.getProperty("FRONTEND_PORT").toInt()) {http ->
         if (http.succeeded()) {
           println("HTTP server started on port ${props.getProperty("FRONTEND_PORT")}")
-          startPromise.complete()
         } else {
           println("Failed to start HTTP server: ${http.cause()}")
           startPromise.fail(http.cause())

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
@@ -13,6 +13,7 @@ import com.ex_dock.ex_dock.database.scope.Websites
 import com.ex_dock.ex_dock.database.server.ServerDataData
 import com.ex_dock.ex_dock.database.server.ServerJDBCVerticle
 import com.ex_dock.ex_dock.database.server.ServerVersionData
+import com.ex_dock.ex_dock.database.service.ServiceVerticle
 import com.ex_dock.ex_dock.database.template.Block
 import com.ex_dock.ex_dock.database.template.Template
 import com.ex_dock.ex_dock.database.template.TemplateJdbcVerticle
@@ -25,10 +26,12 @@ import com.ex_dock.ex_dock.helper.deployWorkerVerticleHelper
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.Future
 import io.vertx.core.Promise
+import io.vertx.core.eventbus.EventBus
 
-class JDBCStarter: AbstractVerticle() {
+class JDBCStarter : AbstractVerticle() {
 
   private var verticles: MutableList<Future<Void>> = emptyList<Future<Void>>().toMutableList()
+  private lateinit var eventBus: EventBus
 
   override fun start(starPromise: Promise<Void>) {
     addAllVerticles()
@@ -37,8 +40,15 @@ class JDBCStarter: AbstractVerticle() {
       .onComplete {
         println("All JDBC verticles deployed")
         getAllCodecClasses()
+        eventBus = vertx.eventBus()
+
+        eventBus.request<String>("process.service.populateTemplates", "").onFailure {
+          // TODO: handle error
+        }.onSuccess {
+          println("Database populated with standard Data")
+        }
       }
-     .onFailure { error ->
+      .onFailure { error ->
         println("Failed to deploy JDBC verticles: $error")
       }
   }
@@ -53,13 +63,49 @@ class JDBCStarter: AbstractVerticle() {
     verticles.add(deployWorkerVerticleHelper(vertx, ScopeJdbcVerticle::class.qualifiedName.toString(), 5, 5))
     verticles.add(deployWorkerVerticleHelper(vertx, ServerJDBCVerticle::class.qualifiedName.toString(), 5, 5))
     verticles.add(deployWorkerVerticleHelper(vertx, UrlJdbcVerticle::class.qualifiedName.toString(), 5, 5))
-    verticles.add(deployWorkerVerticleHelper(vertx, ProductCompleteEavJdbcVerticle::class.qualifiedName.toString(), 5, 5))
+    verticles.add(
+      deployWorkerVerticleHelper(
+        vertx,
+        ProductCompleteEavJdbcVerticle::class.qualifiedName.toString(),
+        5,
+        5
+      )
+    )
     verticles.add(deployWorkerVerticleHelper(vertx, ProductGlobalEavJdbcVerticle::class.qualifiedName.toString(), 5, 5))
-    verticles.add(deployWorkerVerticleHelper(vertx, ProductMultiSelectJdbcVerticle::class.qualifiedName.toString(), 5, 5))
-    verticles.add(deployWorkerVerticleHelper(vertx, ProductStoreViewEavJdbcVerticle::class.qualifiedName.toString(), 5, 5))
-    verticles.add(deployWorkerVerticleHelper(vertx, ProductWebsiteEavJdbcVerticle::class.qualifiedName.toString(), 5, 5))
-    verticles.add(deployWorkerVerticleHelper(vertx, ProductCustomAttributesJdbcVerticle::class.qualifiedName.toString(), 5, 5))
+    verticles.add(
+      deployWorkerVerticleHelper(
+        vertx,
+        ProductMultiSelectJdbcVerticle::class.qualifiedName.toString(),
+        5,
+        5
+      )
+    )
+    verticles.add(
+      deployWorkerVerticleHelper(
+        vertx,
+        ProductStoreViewEavJdbcVerticle::class.qualifiedName.toString(),
+        5,
+        5
+      )
+    )
+    verticles.add(
+      deployWorkerVerticleHelper(
+        vertx,
+        ProductWebsiteEavJdbcVerticle::class.qualifiedName.toString(),
+        5,
+        5
+      )
+    )
+    verticles.add(
+      deployWorkerVerticleHelper(
+        vertx,
+        ProductCustomAttributesJdbcVerticle::class.qualifiedName.toString(),
+        5,
+        5
+      )
+    )
     verticles.add(deployWorkerVerticleHelper(vertx, TemplateJdbcVerticle::class.qualifiedName.toString(), 5, 5))
+    verticles.add(deployWorkerVerticleHelper(vertx, ServiceVerticle::class.qualifiedName.toString(), 1, 1))
   }
 
   private fun getAllCodecClasses() {

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
@@ -13,6 +13,7 @@ import com.ex_dock.ex_dock.database.scope.Websites
 import com.ex_dock.ex_dock.database.server.ServerDataData
 import com.ex_dock.ex_dock.database.server.ServerJDBCVerticle
 import com.ex_dock.ex_dock.database.server.ServerVersionData
+import com.ex_dock.ex_dock.database.service.PopulateException
 import com.ex_dock.ex_dock.database.service.ServiceVerticle
 import com.ex_dock.ex_dock.database.template.Block
 import com.ex_dock.ex_dock.database.template.Template
@@ -43,7 +44,7 @@ class JDBCStarter : AbstractVerticle() {
         eventBus = vertx.eventBus()
 
         eventBus.request<String>("process.service.populateTemplates", "").onFailure {
-          // TODO: handle error
+          throw PopulateException("Could not populate the database with standard data. Closing the server!")
         }.onSuccess {
           println("Database populated with standard Data")
         }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/JDBCStarter.kt
@@ -13,6 +13,9 @@ import com.ex_dock.ex_dock.database.scope.Websites
 import com.ex_dock.ex_dock.database.server.ServerDataData
 import com.ex_dock.ex_dock.database.server.ServerJDBCVerticle
 import com.ex_dock.ex_dock.database.server.ServerVersionData
+import com.ex_dock.ex_dock.database.template.Block
+import com.ex_dock.ex_dock.database.template.Template
+import com.ex_dock.ex_dock.database.template.TemplateJdbcVerticle
 import com.ex_dock.ex_dock.database.text_pages.FullTextPages
 import com.ex_dock.ex_dock.database.text_pages.TextPages
 import com.ex_dock.ex_dock.database.text_pages.TextPagesJdbcVerticle
@@ -56,6 +59,7 @@ class JDBCStarter: AbstractVerticle() {
     verticles.add(deployWorkerVerticleHelper(vertx, ProductStoreViewEavJdbcVerticle::class.qualifiedName.toString(), 5, 5))
     verticles.add(deployWorkerVerticleHelper(vertx, ProductWebsiteEavJdbcVerticle::class.qualifiedName.toString(), 5, 5))
     verticles.add(deployWorkerVerticleHelper(vertx, ProductCustomAttributesJdbcVerticle::class.qualifiedName.toString(), 5, 5))
+    verticles.add(deployWorkerVerticleHelper(vertx, TemplateJdbcVerticle::class.qualifiedName.toString(), 5, 5))
   }
 
   private fun getAllCodecClasses() {
@@ -118,6 +122,8 @@ class JDBCStarter: AbstractVerticle() {
       .registerCodec(GenericCodec(UserCreation::class.java))
       .registerCodec(GenericCodec(BackendPermissions::class.java))
       .registerCodec(GenericCodec(FullUser::class.java))
+      .registerCodec(GenericCodec(Template::class.java))
+      .registerCodec(GenericCodec(Block::class.java))
   }
 
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/category/CategoryJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/category/CategoryJdbcVerticle.kt
@@ -1,6 +1,6 @@
 package com.ex_dock.ex_dock.database.category
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import com.ex_dock.ex_dock.database.product.Products
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.DeliveryOptions
@@ -19,7 +19,7 @@ class CategoryJdbcVerticle: AbstractVerticle() {
   private val seoCategoriesDeliveryOptions = DeliveryOptions().setCodecName("CategoriesSeoCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     // Initialize all eventbus connections for basic categories

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/connection/ConnectionPool.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/connection/ConnectionPool.kt
@@ -1,5 +1,7 @@
 package com.ex_dock.ex_dock.database.connection
 
+import com.ex_dock.ex_dock.ClassLoaderDummy
+import com.ex_dock.ex_dock.MainVerticle
 import io.vertx.core.Vertx
 import io.vertx.jdbcclient.JDBCConnectOptions
 import io.vertx.jdbcclient.JDBCPool
@@ -55,7 +57,7 @@ fun getConnection(vertx: Vertx): Pool {
   val connectOptions = JDBCConnectOptions()
 
   try {
-    val props: Properties = ClassLoader.getSystemClassLoader().getResourceAsStream("secret.properties").use {
+    val props: Properties = ClassLoaderDummy::class.java.classLoader.getResourceAsStream("secret.properties").use {
       Properties().apply { load(it) }
     }
 

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductCompleteEavJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductCompleteEavJdbcVerticle.kt
@@ -1,6 +1,6 @@
 package com.ex_dock.ex_dock.database.product
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.EventBus
 import io.vertx.core.json.JsonObject
@@ -15,7 +15,7 @@ class ProductCompleteEavJdbcVerticle: AbstractVerticle() {
   private val failedMessage: String = "failed"
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     getAllCompleteProductEavData()

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductCustomAttributesJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductCustomAttributesJdbcVerticle.kt
@@ -1,12 +1,9 @@
 package com.ex_dock.ex_dock.database.product
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
-import io.vertx.core.json.JsonObject
-import io.vertx.kotlin.core.json.json
-import io.vertx.kotlin.core.json.obj
 import io.vertx.sqlclient.Pool
 import io.vertx.sqlclient.Row
 import io.vertx.sqlclient.Tuple
@@ -19,7 +16,7 @@ class ProductCustomAttributesJdbcVerticle: AbstractVerticle() {
   private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     getAllCustomAttributes()

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductGlobalEavJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductGlobalEavJdbcVerticle.kt
@@ -1,6 +1,6 @@
 package com.ex_dock.ex_dock.database.product
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
@@ -23,7 +23,7 @@ class ProductGlobalEavJdbcVerticle: AbstractVerticle() {
   private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     getAllEavGlobalBool()

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductMultiSelectJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductMultiSelectJdbcVerticle.kt
@@ -1,6 +1,6 @@
 package com.ex_dock.ex_dock.database.product;
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
@@ -21,7 +21,7 @@ class ProductMultiSelectJdbcVerticle: AbstractVerticle() {
   private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     getAllMultiSelectAttributesBool()

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductStoreViewEavJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductStoreViewEavJdbcVerticle.kt
@@ -1,6 +1,6 @@
 package com.ex_dock.ex_dock.database.product
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
@@ -25,7 +25,7 @@ class ProductStoreViewEavJdbcVerticle: AbstractVerticle() {
 
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     getAllEavStoreViewBool()

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductWebsiteEavJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/product/ProductWebsiteEavJdbcVerticle.kt
@@ -1,6 +1,6 @@
 package com.ex_dock.ex_dock.database.product
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
@@ -24,7 +24,7 @@ class ProductWebsiteEavJdbcVerticle: AbstractVerticle() {
   private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     getAllEavWebsiteBool()

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/scope/ScopeJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/scope/ScopeJdbcVerticle.kt
@@ -1,6 +1,6 @@
 package com.ex_dock.ex_dock.database.scope
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
@@ -18,7 +18,7 @@ class ScopeJdbcVerticle:  AbstractVerticle() {
   private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     // Initialize all eventbus connections for the website table

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/server/ServerJDBCVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/server/ServerJDBCVerticle.kt
@@ -1,14 +1,11 @@
 package com.ex_dock.ex_dock.database.server
 
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.Future
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
 import io.vertx.core.eventbus.Message
-import io.vertx.core.json.JsonObject
-import io.vertx.kotlin.core.json.json
-import io.vertx.kotlin.core.json.obj
 import io.vertx.sqlclient.Pool
 import io.vertx.sqlclient.Row
 import io.vertx.sqlclient.RowSet
@@ -23,7 +20,7 @@ class ServerJDBCVerticle: AbstractVerticle() {
   private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     // Initialize all eventbus connections with the Server Data table

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceData.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceData.kt
@@ -11,3 +11,5 @@ fun getAllStandardTemplates(): List<Template> {
   ))
   return templates.toList()
 }
+
+class PopulateException(message: String) : Exception(message)

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceData.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceData.kt
@@ -5,5 +5,9 @@ import com.ex_dock.ex_dock.database.template.Template
 fun getAllStandardTemplates(): List<Template> {
   val templates: MutableList<Template> = emptyList<Template>().toMutableList()
 
+  templates.add(Template(
+    "testKey",
+    "<test>testData</test>"
+  ))
   return templates.toList()
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceData.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceData.kt
@@ -1,0 +1,9 @@
+package com.ex_dock.ex_dock.database.service
+
+import com.ex_dock.ex_dock.database.template.Template
+
+fun getAllStandardTemplates(): List<Template> {
+  val templates: MutableList<Template> = emptyList<Template>().toMutableList()
+
+  return templates.toList()
+}

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
@@ -4,6 +4,7 @@ import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.EventBus
 import io.vertx.sqlclient.Pool
+import io.vertx.sqlclient.Tuple
 
 class ServiceVerticle: AbstractVerticle() {
   private lateinit var client: Pool
@@ -12,13 +13,28 @@ class ServiceVerticle: AbstractVerticle() {
   override fun start() {
     client = getConnection(vertx)
     eventBus = vertx.eventBus()
+
+    populateTemplateTable()
   }
 
-  fun populateTemplateTable() {
-    val templateList = getAllStandardTemplates()
-    val query = "INSERT INTO templates (template_key, template_data) SELECT "
-    for (template in templateList) {
-      val rowsFuture = client.preparedQuery(query).execute()
+  private fun populateTemplateTable() {
+    eventBus.consumer<Any?>("process.service.populateTemplates").handler { message ->
+      val templateList = getAllStandardTemplates()
+      val query = "INSERT INTO templates (template_key, template_data) SELECT ?, ? " +
+        "WHERE NOT EXISTS(SELECT * FROM templates WHERE template_key = ?)"
+      for (template in templateList) {
+        val rowsFuture = client.preparedQuery(query).execute(Tuple.of(
+          template.templateKey,
+          template.templateData,
+          template.templateKey
+        ))
+
+        rowsFuture.onFailure { res ->
+          println("Failed to execute query: $res")
+        }
+      }
+
+      message.reply("Completed populating templates")
     }
   }
 }

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
@@ -1,0 +1,24 @@
+package com.ex_dock.ex_dock.database.service
+
+import com.ex_dock.ex_dock.database.connection.getConnection
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.eventbus.EventBus
+import io.vertx.sqlclient.Pool
+
+class ServiceVerticle: AbstractVerticle() {
+  private lateinit var client: Pool
+  private lateinit var eventBus: EventBus
+
+  override fun start() {
+    client = getConnection(vertx)
+    eventBus = vertx.eventBus()
+  }
+
+  fun populateTemplateTable() {
+    val templateList = getAllStandardTemplates()
+    val query = "INSERT INTO templates (template_key, template_data) SELECT "
+    for (template in templateList) {
+      val rowsFuture = client.preparedQuery(query).execute()
+    }
+  }
+}

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/service/ServiceVerticle.kt
@@ -31,6 +31,7 @@ class ServiceVerticle: AbstractVerticle() {
 
         rowsFuture.onFailure { res ->
           println("Failed to execute query: $res")
+          message.fail(500, "Failed to execute query")
         }
       }
 

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/template/TemplateClasses.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/template/TemplateClasses.kt
@@ -1,0 +1,10 @@
+package com.ex_dock.ex_dock.database.template
+
+data class Template(
+  val templateKey: String,
+  val templateData: String
+)
+
+data class Block(
+  val templateKey: String,
+)

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/template/TemplateJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/template/TemplateJdbcVerticle.kt
@@ -1,0 +1,284 @@
+package com.ex_dock.ex_dock.database.template
+
+import com.ex_dock.ex_dock.database.connection.getConnection
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.eventbus.DeliveryOptions
+import io.vertx.core.eventbus.EventBus
+import io.vertx.sqlclient.Pool
+import io.vertx.sqlclient.Row
+import io.vertx.sqlclient.Tuple
+
+class TemplateJdbcVerticle: AbstractVerticle() {
+  private lateinit var client: Pool
+  private lateinit var eventBus: EventBus
+
+  private val failedMessage: String = "failed"
+  private val templateDeliveryOptions = DeliveryOptions().setCodecName("TemplateCodec")
+  private val blockDeliveryOptions = DeliveryOptions().setCodecName("BlockCodec")
+  private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
+
+  override fun start() {
+    client = getConnection(vertx)
+    eventBus = vertx.eventBus()
+
+    getAllTemplates()
+    getTemplateByKey()
+    createTemplate()
+    updateTemplate()
+    deleteTemplate()
+
+    getAllBlocks()
+    getBlockByKey()
+    createBlock()
+    updateBlock()
+    deleteBlock()
+  }
+
+  private fun getAllTemplates() {
+    val allTemplateConsumer = eventBus.consumer<Any?>("process.templates.getAllTemplates")
+    allTemplateConsumer.handler { message ->
+      val query = "SELECT * FROM templates"
+      val rowsFuture = client.preparedQuery(query).execute()
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { rows ->
+        val templates: MutableList<Template> = rows.map { makeTemplate(it) }.toMutableList()
+        message.reply(templates, listDeliveryOptions)
+      }
+    }
+  }
+
+  private fun getTemplateByKey() {
+    val getTemplateByKeyConsumer = eventBus.consumer<String>("process.templates.getTemplateByKey")
+    getTemplateByKeyConsumer.handler { message ->
+      val body = message.body()
+      val query = "SELECT * FROM templates WHERE template_key =?"
+      val rowsFuture = client.preparedQuery(query).execute(Tuple.of(body))
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { rows ->
+        if (rows.size() == 1) {
+          val template = makeTemplate(rows.first())
+          message.reply(template, templateDeliveryOptions)
+        } else {
+          message.reply(failedMessage)
+        }
+      }
+    }
+  }
+
+  private fun createTemplate() {
+    val createTemplateConsumer = eventBus.consumer<Template>("process.templates.createTemplate")
+    createTemplateConsumer.handler { message ->
+      val body = message.body()
+      val isPutRequest = message.headers().contains("isPutRequest")
+      val templateTuple = makeTemplateTuple(body, isPutRequest)
+      val query = "INSERT INTO templates (template_data, template_key) VALUES (?,?)"
+
+      val rowsFuture = client.preparedQuery(query).execute(templateTuple)
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { _ ->
+        message.reply(body, templateDeliveryOptions)
+      }
+    }
+  }
+
+  private fun updateTemplate() {
+    val updateTemplateConsumer = eventBus.consumer<Template>("process.templates.updateTemplate")
+    updateTemplateConsumer.handler { message ->
+      val body = message.body()
+      val isPutRequest = message.headers().contains("isPutRequest")
+      val templateTuple = makeTemplateTuple(body, isPutRequest)
+      val query = "UPDATE templates SET template_data =? WHERE template_key =?"
+
+      val rowsFuture = client.preparedQuery(query).execute(templateTuple)
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { _ ->
+        message.reply(body, templateDeliveryOptions)
+      }
+    }
+  }
+
+  private fun deleteTemplate() {
+    val deleteTemplateConsumer = eventBus.consumer<String>("process.templates.deleteTemplate")
+    deleteTemplateConsumer.handler { message ->
+      val body = message.body()
+      val query = "DELETE FROM templates WHERE template_key =?"
+
+      val rowsFuture = client.preparedQuery(query).execute(Tuple.of(body))
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { _ ->
+        message.reply("Successfully deleted template")
+      }
+    }
+  }
+
+  private fun getAllBlocks() {
+    val allBlocksConsumer = eventBus.consumer<Any?>("process.blocks.getAllBlocks")
+    allBlocksConsumer.handler { message ->
+      val query = "SELECT * FROM blocks"
+      val rowsFuture = client.preparedQuery(query).execute()
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { rows ->
+        val blocks: MutableList<Block> = rows.map { makeBlock(it) }.toMutableList()
+        message.reply(blocks, listDeliveryOptions)
+      }
+    }
+  }
+
+  private fun getBlockByKey() {
+    val getBlockByKeyConsumer = eventBus.consumer<String>("process.blocks.getBlockByKey")
+    getBlockByKeyConsumer.handler { message ->
+      val body = message.body()
+      val query = "SELECT * FROM blocks WHERE template_key =?"
+      val rowsFuture = client.preparedQuery(query).execute(Tuple.of(body))
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { rows ->
+        if (rows.size() == 1) {
+          val block = makeBlock(rows.first())
+          message.reply(block, blockDeliveryOptions)
+        } else {
+          message.reply(failedMessage)
+        }
+      }
+    }
+  }
+
+  private fun createBlock() {
+    val createBlockConsumer = eventBus.consumer<Block>("process.blocks.createBlock")
+    createBlockConsumer.handler { message ->
+      val body = message.body()
+      val isPutRequest = message.headers().contains("isPutRequest")
+      val blockTuple = makeBlockTuple(body, isPutRequest)
+      val query = "INSERT INTO blocks (template_key) VALUES (?)"
+
+      val rowsFuture = client.preparedQuery(query).execute(blockTuple)
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { _ ->
+        message.reply(body, blockDeliveryOptions)
+      }
+    }
+  }
+
+  private fun updateBlock() {
+    val updateBlockConsumer = eventBus.consumer<Block>("process.blocks.updateBlock")
+    updateBlockConsumer.handler { message ->
+      val body = message.body()
+      val isPutRequest = message.headers().contains("isPutRequest")
+      val blockTuple = makeBlockTuple(body, isPutRequest)
+      val query = "UPDATE blocks SET template_key =? WHERE template_key =?"
+
+      val rowsFuture = client.preparedQuery(query).execute(blockTuple)
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { _ ->
+        message.reply(body, blockDeliveryOptions)
+      }
+    }
+  }
+
+  private fun deleteBlock() {
+    val deleteBlockConsumer = eventBus.consumer<String>("process.blocks.deleteBlock")
+    deleteBlockConsumer.handler { message ->
+      val body = message.body()
+      val query = "DELETE FROM blocks WHERE template_key =?"
+
+      val rowsFuture = client.preparedQuery(query).execute(Tuple.of(body))
+
+      rowsFuture.onFailure { res ->
+        println("Failed to execute query: $res")
+        message.reply(failedMessage)
+      }
+
+      rowsFuture.onSuccess { _ ->
+        message.reply("Successfully deleted block")
+      }
+    }
+  }
+
+  private fun makeTemplate(row: Row): Template {
+    return Template(
+      row.getString("template_key"),
+      row.getString("template_data")
+    )
+  }
+
+  private fun makeBlock(row: Row): Block {
+    return Block(
+      row.getString("block_key"),
+    )
+  }
+
+  private fun makeTemplateTuple(body: Template, isPutRequest: Boolean): Tuple {
+    val templateTuple = if (isPutRequest) {
+      Tuple.of(
+        body.templateData,
+        body.templateKey,
+      )
+    } else {
+      Tuple.of(
+        body.templateKey,
+        body.templateData
+      )
+    }
+
+    return templateTuple
+  }
+
+  private fun makeBlockTuple(body: Block, isPutRequest: Boolean): Tuple {
+    val blockTuple = if (isPutRequest) {
+      Tuple.of(
+        body.templateKey,
+        body.templateKey
+      )
+    } else {
+      Tuple.of(
+        body.templateKey
+      )
+    }
+
+    return blockTuple
+  }
+}

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/text_pages/TextPagesJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/text_pages/TextPagesJdbcVerticle.kt
@@ -1,11 +1,10 @@
 package com.ex_dock.ex_dock.database.text_pages
 
 import com.ex_dock.ex_dock.database.category.PageIndex
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
-import io.vertx.core.json.JsonObject
 import io.vertx.jdbcclient.JDBCPool
 import io.vertx.sqlclient.Pool
 import io.vertx.sqlclient.Row
@@ -22,7 +21,7 @@ class TextPagesJdbcVerticle: AbstractVerticle() {
   private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     // Initialize the eventbus connections with the text pages table

--- a/src/main/kotlin/com/ex_dock/ex_dock/database/url/UrlJdbcVerticle.kt
+++ b/src/main/kotlin/com/ex_dock/ex_dock/database/url/UrlJdbcVerticle.kt
@@ -1,7 +1,7 @@
 package com.ex_dock.ex_dock.database.url
 
 import com.ex_dock.ex_dock.database.category.Categories
-import com.ex_dock.ex_dock.database.connection.Connection
+import com.ex_dock.ex_dock.database.connection.getConnection
 import com.ex_dock.ex_dock.database.product.Products
 import com.ex_dock.ex_dock.database.text_pages.TextPages
 import io.vertx.core.AbstractVerticle
@@ -23,7 +23,7 @@ class UrlJdbcVerticle: AbstractVerticle() {
   private val listDeliveryOptions = DeliveryOptions().setCodecName("ListCodec")
 
   override fun start() {
-    client = Connection().getConnection(vertx)
+    client = getConnection(vertx)
     eventBus = vertx.eventBus()
 
     // Initialize all eventbus connections with the url_keys table


### PR DESCRIPTION
Adds the template tables to the JDBC. Also adds the service verticle to verticles.
## Template JDBC
Standard JDBC verticle to handle the requests to the template and block table in the database.
## Service verticle
Verticle for all other service task that need to be done. This only runs 1 worker and doesn't need to run multiple. This can't be changed by now and probably also doesn't need to be changed later. The ServiceData.kt file holds all data that the verticle needs. For now it only has a list with templates that get inserted in the database if it is not already in. This throws a custom PopulateException when there is an error with population. This has the reason that otherwise the users might not be able to do anything if there is no data at the start.

# Depends on #43  